### PR TITLE
Add 'courses' to to valid URL test.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -27,7 +27,7 @@ if (process.argv.slice(2).length < 2) {
   process.exit()
 }
 
-if (!/egghead.io\/(lessons|series|playlists)\//.test(urlValue)) {
+if (!/egghead.io\/(lessons|series|playlists|courses)\//.test(urlValue)) {
   error('unsupported url!')
 }
 


### PR DESCRIPTION
Allow URL's containing 'courses' (such as https://egghead.io/courses/building-react-applications-with-idiomatic-redux) to be downloaded.  These are essentially the same as 'series'.