### PR TITLE
Pad counts in filenames and stdout

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -54,12 +54,13 @@ async function doTheMagic () {
   let i = 0
   for (const {url, filename} of videos) {
     i++
-    const p = path.join(outputDir, (program.count ? `${i}-${filename}` : filename))
+    let paddedCounter = `00${i}`.slice(-2) 
+    const p = path.join(outputDir, (program.count ? `${paddedCounter}-${filename}` : filename))
     if (!program.force && fileExists(p)) {
-      console.log(`File ${i}-${filename} already exists, skip`)
+      console.log(`File ${paddedCounter}-${filename} already exists, skip`)
       continue
     }
-    progress.start(`Downloading video ${i} out of ${videos.length}: '${filename}'`)
+    progress.start(`Downloading video ${paddedCounter} out of ${videos.length}: '${filename}'`)
     const stream = fs.createWriteStream(p)
     await new Promise((resolve, reject) => {
       request(url)


### PR DESCRIPTION
Padded filename counts so that they're ordered correctly on `ls` and in Finder. Also padded file names in stdout so that it was consistent between interfaces. This assumes that no courses would have greater than 99 lessons, otherwise the number will be truncated. If so, we can check the total length of videos and use that to determine the pad amount.

Edit: thanks to @mattaudesse there's now also dynamic padding!