### PR TITLE
Tweak .babelrc so the app runs on current LTS version of Node (4.5.0)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015-node"],
-  "plugins": ["transform-async-to-generator"]
+  "plugins": ["transform-async-to-generator", "transform-es2015-destructuring", "transform-es2015-parameters"]
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "downloader"
   ],
   "engines" : {
-    "node" : ">=6.0.0"
+    "node" : ">=4.5.0"
   },
   "preferGlobal": true,
   "bin": {


### PR DESCRIPTION
Hi
This pull request makes it possible to use your tool with current LTS version of Node (4.5.0).
I haven't checked if it runs on earlier versions.
This should also solve #10. 